### PR TITLE
Delete dub.selections.json

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,4 +1,0 @@
-{
-	"versions": {},
-	"fileVersion": 1
-}


### PR DESCRIPTION
You should almost never check in `dub.selections.json`, only if you need to be very unusually specific about dependencies.